### PR TITLE
Fix the "id" fieldnames for ProductDetails_V view

### DIFF
--- a/src/update.sql
+++ b/src/update.sql
@@ -83,6 +83,6 @@ p.*,
 c.CategoryName, c.Description as [CategoryDescription],
 s.CompanyName as [SupplierName], s.Region as [SupplierRegion]
 from [Products] p
-join [Categories] c on p.CategoryId = c.id
-join [Suppliers] s on s.id = p.SupplierId;
+join [Categories] c on p.CategoryId = c.CategoryId
+join [Suppliers] s on s.SupplierId = p.SupplierId;
 


### PR DESCRIPTION
The "id" fieldnames seem to have been changed to "TablenameId" during the rebuild 2 weeks ago, but this view was not updated. This fixes that issue.